### PR TITLE
Send not found message if role not found

### DIFF
--- a/role-assignment/role-assignment.py
+++ b/role-assignment/role-assignment.py
@@ -106,6 +106,7 @@ class RoleAssignment(Cog):
         role = discord.utils.get(guild.roles, name=role)
 
         if role is None:
+            await guild.get_channel(payload.channel_id).send('Configured role not found.')
             return
 
         for m in guild.members:

--- a/role-assignment/role-assignment.py
+++ b/role-assignment/role-assignment.py
@@ -134,6 +134,7 @@ class RoleAssignment(Cog):
         role = discord.utils.get(guild.roles, name=role)
 
         if role is None:
+            await guild.get_channel(payload.channel_id).send('Configured role not found.')
             return
 
         for m in guild.members:


### PR DESCRIPTION
# Whats This?

* Due to some reasons, if role was deleted and the bot couldn't find the role, role wouldn't being added and the user can be confused why so, for that with changes in this pr,  we throw an error message